### PR TITLE
Introduce automatic Queen promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode
 /node_modules
 /css/main.css.map
+.idea

--- a/src/board.ts
+++ b/src/board.ts
@@ -46,6 +46,9 @@ function renderBoard(boardMatrix: Piece[][], board: Element): void {
     for (let i = 7; i >= 0; i--) {
         for (let j = 0; j< 8; j++) {
             if (boardMatrix[i][j] !== undefined && boardMatrix[i][j] !== null) {
+                if (boardMatrix[i][j].promote){
+                    boardMatrix[i][j] = new Queen(i,j,boardMatrix[i][j].color);
+                }
                 // Pick what is the piece
                 const piece = boardMatrix[i][j].constructor["name"].toLowerCase();
                 const { color } = boardMatrix[i][j];

--- a/src/clicksEvents.ts
+++ b/src/clicksEvents.ts
@@ -3,6 +3,7 @@ import { Color } from './pieces/piece';
 import { boardMatrix } from "./board";
 import { isInCheck } from "./check";
 
+
 export let playerColor: Color = 'white'; 
 let hasClickedAPiece = false;
 let firstPieceDTO: IPieceDTO;
@@ -38,9 +39,9 @@ export function secondClick(target: EventTarget) {
       hasClickedAPiece = false;
       firstClick(target);
     } else {
-      const sucess = tryMovement(firstPieceDTO, secondPieceDTO, playerColor);
+      const success = tryMovement(firstPieceDTO, secondPieceDTO, playerColor);
       hasClickedAPiece = false;
-      if (sucess) {
+      if (success) {
         playerColor = changePlayer(playerColor);
       }
     }

--- a/src/game.ts
+++ b/src/game.ts
@@ -2,6 +2,7 @@ import { boardMatrix, renderBoard } from './board';
 import { Piece, Color } from './pieces/piece';
 import { firstClick, secondClick } from "./clicksEvents";
 
+
 export const board = document.querySelector('.board');
 
 export interface ICoordinate {
@@ -26,12 +27,14 @@ export function tryMovement({ pieceInstance }: IPieceDTO, { coord }: IPieceDTO, 
   });
   
   let checkEspecialMovements = especialMovements(pieceInstance, coord);
-
   if (!checkEspecialMovements && !!check) {
     if (pieceInstance.constructor["name"].toLowerCase() === 'pawn') {
       console.log(pieceInstance.doubleMovementTurn);
       if (Math.abs(coord.row - pieceInstance.row) === 2) {
         pieceInstance.doubleMovementTurn = Piece.turn;
+      }
+      if(coord.row == 0 || coord.row == 7){
+        pieceInstance.promote = true;
       }
     }
     pieceInstance.doMovement(coord, boardMatrix);

--- a/src/pieces/piece.ts
+++ b/src/pieces/piece.ts
@@ -2,6 +2,7 @@ import { ICoordinate, board, findKingCoord } from '../game';
 import { renderBoard } from '../board';
 import { isInCheck } from '../check';
 
+
 export type Color = 'white' | 'black'
 
 export interface IPiece {
@@ -9,11 +10,13 @@ export interface IPiece {
     column: number
     color: Color
     Moved: boolean
+    promote: boolean
     doubleMovementTurn: number
 }
 
 export abstract class Piece implements IPiece {
     public Moved: boolean;
+    public promote: boolean;
     static turn: number = 1; 
     public doubleMovementTurn: number = -1;    
 
@@ -23,6 +26,7 @@ export abstract class Piece implements IPiece {
         this.column = column;
         this.color = color;
         this.Moved = false;
+        this.promote = false;
     }
 
     possibleMovementsList(board: Piece[][]): ICoordinate[] {
@@ -30,10 +34,11 @@ export abstract class Piece implements IPiece {
     }
 
     doMovement({ row, column }: ICoordinate, matrix: Piece[][]) {
+
         matrix[this.row][this.column] = null;
         this.Moved = true;
         this.row = row;
-        this.column = column
+        this.column = column;
 
         matrix[row][column] = null;
         renderBoard(matrix, board);


### PR DESCRIPTION
This is my initial implementation of promoting pawns. As is, this will automatically promote a pawn to Queen. I hope this groundwork can be leveraged to allow for dynamic promotion (to N, R, or B) in the future.

These canges introduce a new property on IPiece called promote which is a flag that is looked for by the renderBoard function. If true, it will change the piece to a Queen before rendering.